### PR TITLE
Use the proper coordinate space when getting the window's dimensions.

### DIFF
--- a/draggable.lua
+++ b/draggable.lua
@@ -8,7 +8,7 @@ function Draggable.move(dx, dy)
   if dragging then
     local start_x, start_y, display_index = love.window.getPosition()
     local display_w, display_h = love.window.getDesktopDimensions(display_index)
-    local win_w, win_h = love.graphics.getDimensions()
+    local win_w, win_h = love.window.getMode()
 
     -- prevent window from moving > 80% out of current display
     local minimum_x = -0.8 * win_w


### PR DESCRIPTION
If high-dpi mode is enabled when a Retina display is used in OS X, love.graphics.getDimensions will return the screen size in pixels, but the desktop dimensions, window position, and window width and height as passed into setMode and retrieved via getMode will all be scaled up (they're in a different coordinate space than pixels.)

Since the dragging calculations use the desktop's coordinate space, the window dimensions should be calculated with love.window.getMode rather than love.graphics.getDimensions.
